### PR TITLE
feat: Center, test, and document the TaskManager component

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -29,7 +29,7 @@ ul, li {
   box-shadow: 0 4px 24px rgba(0,0,0,0.08);
   max-width: 420px;
   width: 100%;
-  margin: 3rem 0;
+  margin: 0;
   padding: 2rem 2rem 1.5rem 2rem;
   display: flex;
   flex-direction: column;

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/client/src/TaskApp.test.tsx
+++ b/client/src/TaskApp.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MockedProvider, MockLink } from '@apollo/client/testing';
+import App from './App';
+import { GET_TASKS, ADD_TASK, UPDATE_TASK, DELETE_TASK } from './App';
+
+const mocks = [
+  {
+    request: {
+      query: GET_TASKS,
+    },
+    result: {
+      data: {
+        tasks: [{ id: '1', title: 'Test Task', completed: false, __typename: 'Task' }],
+      },
+    },
+  },
+  {
+    request: {
+      query: ADD_TASK,
+      variables: { title: 'New Task' },
+    },
+    result: {
+      data: {
+        addTask: { id: '2', title: 'New Task', completed: false, __typename: 'Task' },
+      },
+    },
+  },
+  {
+    request: {
+      query: UPDATE_TASK,
+      variables: { id: '1', completed: true },
+    },
+    result: {
+      data: {
+        updateTask: { id: '1', title: 'Test Task', completed: true, __typename: 'Task' },
+      },
+    },
+  },
+  {
+    request: {
+      query: DELETE_TASK,
+      variables: { id: '1' },
+    },
+    result: {
+      data: {
+        deleteTask: '1',
+      },
+    },
+  },
+];
+
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+
+describe('TaskApp', () => {
+  it('renders loading state initially', () => {
+    const mockClient = new ApolloClient({
+      link: new MockLink(mocks),
+      cache: new InMemoryCache(),
+    });
+    render(
+      <App client={mockClient} />
+    );
+    expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+  });
+
+  it('renders tasks', async () => {
+    const mockClient = new ApolloClient({
+      link: new MockLink(mocks),
+      cache: new InMemoryCache(),
+    });
+    render(
+      <App client={mockClient} />
+    );
+    await waitFor(() => expect(screen.getByText(/Test Task/i)).toBeInTheDocument());
+  });
+
+  it('adds a task', async () => {
+    const newMocks = [
+      mocks[0],
+      {
+        request: {
+          query: ADD_TASK,
+          variables: { title: 'New Task' },
+        },
+        result: {
+          data: {
+            addTask: { id: '2', title: 'New Task', completed: false, __typename: 'Task' },
+          },
+        },
+      },
+      {
+        request: {
+          query: GET_TASKS,
+        },
+        result: {
+          data: {
+            tasks: [
+              { id: '1', title: 'Test Task', completed: false, __typename: 'Task' },
+              { id: '2', title: 'New Task', completed: false, __typename: 'Task' },
+            ],
+          },
+        },
+      },
+    ];
+    const mockClient = new ApolloClient({
+      link: new MockLink(newMocks),
+      cache: new InMemoryCache(),
+    });
+
+    render(
+      <App client={mockClient} />
+    );
+    await waitFor(() => expect(screen.getByText(/Test Task/i)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText(/New task title/i), {
+      target: { value: 'New Task' },
+    });
+    fireEvent.click(screen.getByText(/Add/i));
+
+    await waitFor(() => expect(screen.getByText(/New Task/i)).toBeInTheDocument());
+  });
+
+  it('toggles a task', async () => {
+    const updatedMocks = [
+      mocks[0],
+      {
+        request: {
+          query: UPDATE_TASK,
+          variables: { id: '1', completed: true },
+        },
+        result: {
+          data: {
+            updateTask: { id: '1', title: 'Test Task', completed: true, __typename: 'Task' },
+          },
+        },
+      },
+      {
+        request: {
+          query: GET_TASKS,
+        },
+        result: {
+          data: {
+            tasks: [{ id: '1', title: 'Test Task', completed: true, __typename: 'Task' }],
+          },
+        },
+      },
+    ];
+    const mockClient = new ApolloClient({
+      link: new MockLink(updatedMocks),
+      cache: new InMemoryCache(),
+    });
+
+    render(
+      <App client={mockClient} />
+    );
+    await waitFor(() => expect(screen.getByText(/Test Task/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    await waitFor(() => {
+      const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+  });
+
+  it('deletes a task', async () => {
+    const newMocks = [
+      mocks[0],
+      {
+        request: {
+          query: DELETE_TASK,
+          variables: { id: '1' },
+        },
+        result: {
+          data: {
+            deleteTask: '1',
+          },
+        },
+      },
+      {
+        request: {
+          query: GET_TASKS,
+        },
+        result: {
+          data: {
+            tasks: [],
+          },
+        },
+      },
+    ];
+    const mockClient = new ApolloClient({
+      link: new MockLink(newMocks),
+      cache: new InMemoryCache(),
+    });
+
+    render(
+      <App client={mockClient} />
+    );
+    await waitFor(() => expect(screen.getByText(/Test Task/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTitle(/Delete/i));
+
+    await waitFor(() => expect(screen.queryByText(/Test Task/i)).not.toBeInTheDocument());
+  });
+});

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import App from './App';
+import App, { createClient } from './App';
 import reportWebVitals from './reportWebVitals';
 
+const client = createClient();
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <App client={client} />
   </React.StrictMode>
 );
 


### PR DESCRIPTION
This commit introduces several improvements to the TaskManager component:

- The TaskManager component is now centered on the screen.
- Comprehensive tests have been added for the TaskManager component, covering adding, toggling, and deleting tasks.
- The code for the TaskManager component has been documented with JSDoc comments.
- The Apollo Client configuration has been updated to address deprecation warnings and to facilitate testing.